### PR TITLE
Assign algorithms per app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,23 +18,23 @@ node index.js
 
 ## API
 
-### `POST /encrypt?app=<算法或中文名称>`
+### `POST /encrypt?app=<应用名称>`
 
-请求体为需要加密的数据，可以是任意 JSON。`app` 参数决定加密算法：
+请求体为需要加密的数据，可以是任意 JSON。服务会根据 `app` 名称选择对应的算法，映射关系在 `index.js` 中的 `appAlgorithms` 变量里定义。
 
-- `sha256` 或 `哈希`：返回 SHA-256 哈希。
- - `aes` 或 `对称`：使用 AES-256-CBC 加密。
- - 其他值：返回 Base64 编码。
+- `hashApp`：返回 SHA-256 哈希。
+- `aesApp`：使用 AES-256-CBC 加密。
+- 未配置的应用：返回 `unknown app` 错误。
 
 示例：
 
 ```bash
-curl -X POST "http://localhost:3000/encrypt?app=哈希" \
+curl -X POST "http://localhost:3000/encrypt?app=hashApp" \
   -H "Content-Type: application/json" \
   -d '{"text":"hello"}'
 ```
 
-加密实现位于 `encryption.js`，可用于对接或自定义扩展。
+加密实现位于 `encryption.js`，可根据需要修改或扩展。
 
 ### `GET /info`
 

--- a/encryption.js
+++ b/encryption.js
@@ -1,7 +1,7 @@
 const crypto = require('crypto');
 
-function encrypt(text, appName) {
-  switch (appName) {
+function encrypt(text, algorithm) {
+  switch (algorithm) {
     case 'sha256':
     case 'SHA256':
     case '哈希':

--- a/index.js
+++ b/index.js
@@ -7,11 +7,22 @@ app.use(express.static('public'));
 
 const visits = {};
 
+// Each app name maps to its dedicated algorithm
+const appAlgorithms = {
+  hashApp: 'sha256',
+  aesApp: 'aes'
+};
+
 app.post('/encrypt', (req, res) => {
   const appName = req.query.app;
   const data = req.body;
   if (!data || !appName) {
     return res.status(400).json({ error: 'missing body or app' });
+  }
+
+  const algorithm = appAlgorithms[appName];
+  if (!algorithm) {
+    return res.status(400).json({ error: 'unknown app' });
   }
   let text;
   if (typeof data === 'string') {
@@ -21,7 +32,7 @@ app.post('/encrypt', (req, res) => {
   } else {
     text = JSON.stringify(data);
   }
-  const result = encrypt(text, appName);
+  const result = encrypt(text, algorithm);
   res.json({ encrypted: result });
 });
 


### PR DESCRIPTION
## Summary
- Map known app names to their dedicated encryption algorithms.
- Validate app names before encryption and return errors for unknown apps.
- Document per-app algorithm mapping and updated usage example.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a70f6aa9ac83208f07fa3b31cb0db0