### PR TITLE
feat: track visit history and style info page

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,7 +39,13 @@ app.post('/encrypt', (req, res) => {
 app.get('/info', async (req, res) => {
   const ip = (req.headers['x-forwarded-for'] || req.connection.remoteAddress || req.ip || '').replace('::ffff:', '');
   const now = new Date();
-  visits[ip] = (visits[ip] || 0) + 1;
+
+  if (!visits[ip]) {
+    visits[ip] = { count: 0, times: [] };
+  }
+  visits[ip].count += 1;
+  visits[ip].times.push(now.toISOString());
+
   let location = {};
   try {
     const response = await fetch(`http://ip-api.com/json/${ip}`);
@@ -47,7 +53,7 @@ app.get('/info', async (req, res) => {
   } catch (e) {
     location = { error: 'lookup failed' };
   }
-  res.json({ ip, location, count: visits[ip], time: now.toISOString() });
+  res.json({ ip, location, count: visits[ip].count, times: visits[ip].times });
 });
 
 const port = process.env.PORT || 3000;

--- a/public/index.html
+++ b/public/index.html
@@ -3,13 +3,17 @@
 <head>
   <meta charset="UTF-8" />
   <title>Visitor Info</title>
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <h1>Visitor Info</h1>
-  <p>IP: <span id="ip"></span></p>
-  <p>Location: <span id="location"></span></p>
-  <p>Visit count: <span id="count"></span></p>
-  <p>Time: <span id="time"></span></p>
+  <div class="container">
+    <h1>Visitor Info</h1>
+    <div class="info-item">IP: <span id="ip"></span></div>
+    <div class="info-item">Location: <span id="location"></span></div>
+    <div class="info-item">Visit count: <span id="count"></span></div>
+    <div class="info-item">Visit times:</div>
+    <ul id="times"></ul>
+  </div>
   <script>
     async function loadInfo() {
       const res = await fetch('/info');
@@ -21,7 +25,14 @@
         document.getElementById('location').textContent = 'Unknown';
       }
       document.getElementById('count').textContent = data.count;
-      document.getElementById('time').textContent = new Date(data.time).toLocaleString();
+
+      const timesList = document.getElementById('times');
+      timesList.innerHTML = '';
+      data.times.forEach(t => {
+        const li = document.createElement('li');
+        li.textContent = new Date(t).toLocaleString();
+        timesList.appendChild(li);
+      });
     }
     loadInfo();
   </script>

--- a/public/style.css
+++ b/public/style.css
@@ -1,0 +1,33 @@
+body {
+  font-family: Arial, sans-serif;
+  background: #f0f2f5;
+  color: #333;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  margin: 0;
+}
+
+.container {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  max-width: 400px;
+  width: 100%;
+}
+
+h1 {
+  text-align: center;
+  margin-top: 0;
+}
+
+.info-item {
+  margin: 0.5rem 0;
+}
+
+#times {
+  padding-left: 1.2rem;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- track visitor counts and history in /info endpoint
- display IP, location and visit history in styled web page
- add basic CSS styling for improved presentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a722e7fde483208bd4df6af0281509